### PR TITLE
EnemyChomper prefab edited

### DIFF
--- a/Assets/Prefabs/Enemy/EnemyChomper.prefab
+++ b/Assets/Prefabs/Enemy/EnemyChomper.prefab
@@ -30,7 +30,7 @@ Transform:
   m_GameObject: {fileID: 4109099630330071814}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 18, y: -2.5, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.6, y: 0.6, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -96,7 +96,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.24637032, y: 0.41081512}
+  m_Offset: {x: 0.112466276, y: 0.42875892}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.25}
@@ -107,7 +107,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.9987297, y: 0.58011127}
+  m_Size: {x: 1.1075298, y: 0.8007723}
   m_EdgeRadius: 0
 --- !u!114 &4109099630330071812
 MonoBehaviour:

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -238,5 +238,5 @@ MonoBehaviour:
   scoreController: {fileID: 0}
   healthController: {fileID: 0}
   playerSpeed: 5
-  jumpAmount: 5
+  jumpAmount: 4
   crouchedSpeed: 2.5

--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -307,6 +307,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 158529130140363235}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &173854810 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+    type: 3}
+  m_PrefabInstance: {fileID: 1362544480}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &181729665
 GameObject:
   m_ObjectHideFlags: 0
@@ -968,6 +974,7 @@ Transform:
   - {fileID: 1494252129}
   - {fileID: 795422968}
   - {fileID: 382252816}
+  - {fileID: 173854810}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1069,7 +1076,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 382252815}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 22.1, y: -2.5, z: 0}
+  m_LocalPosition: {x: 22.08, y: -2.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 209525754}
@@ -1131,7 +1138,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 795422967}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 14, y: -2.5, z: 0}
+  m_LocalPosition: {x: 14.09, y: -2.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 209525754}
@@ -1270,6 +1277,75 @@ Transform:
   m_Father: {fileID: 209525754}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1362544480
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 209525754}
+    m_Modifications:
+    - target: {fileID: 4109099630330071814, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_Name
+      value: EnemyChomper2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30, type: 3}
 --- !u!4 &1494252129 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
@@ -2750,12 +2826,12 @@ PrefabInstance:
     - target: {fileID: 1494926571590090870, guid: 93573c0d915543a4a9f281e8cda434f1,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.17
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1494926571590090870, guid: 93573c0d915543a4a9f281e8cda434f1,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.12
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1494926571590090870, guid: 93573c0d915543a4a9f281e8cda434f1,
         type: 3}
@@ -2824,12 +2900,12 @@ PrefabInstance:
     - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 18
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.6
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 4109099630330071815, guid: 4ffc8dc1420061c4cbeecdcb8a7b8d30,
         type: 3}


### PR DESCRIPTION
- Enemy Prefab
 -EnemyChomper size adjusted according to player size
 -BoxCollider adjusted boundary
 -Added second enemy to get some idea of collision matrix, Prefab instances can have different transform values for position and rotation, however changing scale of enemy prefab on one instance overrides in second instance as well.

- Player Prefab
 -Reduced jump amount value.