### PR TITLE
Update GameOverController.cs

### DIFF
--- a/Assets/Scripts/GameOverController.cs
+++ b/Assets/Scripts/GameOverController.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
-using UnityEngine.SceneManagement;
 
 public class GameOverController : MonoBehaviour
 {


### PR DESCRIPTION
UnityEngine.SceneManagement is now used only inside LevelManager.